### PR TITLE
Clean up recon copy

### DIFF
--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -6,18 +6,18 @@ discussions-to: https://forum.ceramic.network/t/cip-124-recon-tip-synchronizatio
 status: Draft
 category: Networking
 created: 2023-01-18
-edited: 2023-05-25
+edited: 2023-06-05
 ---
 ## Simple Summary
 
 <!--Provide a simplified and layman-accessible explanation of the CIP.-->
-Recon is a sets reconciliation protocol to be used for synchronization of stream events in ceramic network.
+Recon is a set reconciliation protocol to be used for synchronization of stream events in ceramic network.
 Stream sets bundle a number of streams together, so that nodes with a common interest of streams can synchronize efficiently. Once a set of streams is bundled into a stream set, Recon can be used to sync ranges of events within those sets.
 
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-Stream sets are bundles of streams that can be gossiped about as a group or in sub-ranges. In order to make ranges possible over a set of streams we need to define an order for the ranges to be over. By assigning an eventId of to event, we can define a range over the lexicographic sort of these eventIds. Now a node can advertise a have/want over a range `(first_event_id, range_hash, last_event_id)` If the node receiving the advertisements has the same set of events, then they will have the same hash and are in sync. If a node needs to advertise a new event it can send `(first_event_id, range_hash, new_event_id, range_hash, last_event_id)` This tells any receiving node not only the new eventId, but asserts all events in the range. If the receiving node has any additional or missing events in this range it is detected and can be synchronized. New nodes interested in a range of a stream set can be discovered in two ways. First, if a node receives a have/want advertisement from a node it can add that node to its list of peers. Second, nodes should advertise their wants to other known nodes in the network.
+Stream sets are bundles of streams that can be gossiped about as a group or in sub-ranges. In order to make ranges possible over a set of streams we need to define an order for the ranges to be over. By assigning an eventId to an event, we can define a range over the lexicographic sort of these eventIds. Now a node can advertise a have/want over a range `(first_event_id, range_hash, last_event_id)` If the node receiving the advertisements has the same set of events, then they will have the same hash and are in sync. If a node needs to advertise a new event it can send `(first_event_id, range_hash, new_event_id, range_hash, last_event_id)` This tells any receiving node not only the new eventId, but asserts all events in the range. If the receiving node has any additional or missing events in this range it is detected and can be synchronized. New nodes interested in a range of a stream set can be discovered in two ways. First, if a node receives a have/want advertisement from a node it can add that node to its list of peers. Second, nodes should advertise their wants to other known nodes in the network.
 
 
 ## Motivation
@@ -26,7 +26,7 @@ Currently nodes broadcast updates to streams to every node in the network using 
 
 Recon aims to provide low to no overhead for nodes with no overlap in interest, while retaining a high probability of getting the **latest** events from a stream shortly after any node has the events, without any need for remote connections at query time. By ceasing to publish updates in the pubsub channel and instead organizing them into a stream set, nodes interested in those streams can synchronize with each other without putting load on uninterested nodes in the network. A secondary goal of stream sets is to give a structure for sharding a stream set across mulitple nodes. By supporting the ability to synchronize only a sub-range of the stream set, the burden of storing, indexing, and retrieving streams can be sharded among nodes. 
 
-Finally, nodes also need a way to find other nodes interested in the stream set or sub-range, so that they can synchronize with them. Recon relies on nodes gossiping their interest to peers, as well as keeping a list of their peers interest. This way nodes that are in sync, or nearly in sync, stay in sync with very little bandwidth. Nodes can also avoid sending stream event announcements to nodes that have no interest in the stream ranges. 
+Finally, nodes also need a way to find other nodes interested in the stream set or sub-range, so that they can synchronize with them. Recon relies on nodes gossiping their interest to peers, as well as keeping a list of their peers' interest. This way nodes that are in sync, or nearly in sync, stay in sync with very little bandwidth. Nodes can also avoid sending stream event announcements to nodes that have no interest in the stream ranges. 
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature.-->
@@ -264,7 +264,7 @@ eventId = concatBytes(
 
 ### Interest ranges
 
-At the core of the design of recon there is the concept of an interest range. Essentially a range is an ordered list of events across multiple streams. By using ranges to specify interest we allow nodes to have partial overlap with each other. This is useful because it removes the need for the network to have a uniform topology. Instead each node can chose to subscribe to as many or as few streams as they like to.
+At the core of the design of recon there is the concept of an interest range. Essentially a range is an ordered list of events across multiple streams. By using ranges to specify interest we allow nodes to have partial overlap with each other. This is useful because it enables node operators to set up sharding strategies based on their needs. Essentially each node can chose to subscribe to as many or as few streams as they need.
 
 ### Sort key and value
 

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -339,7 +339,8 @@ This approach was rejected because it does not solve the missed messages problem
 
 ## Backwards Compatibility
 <!--All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility section may be rejected outright.-->
-This protocol should run in parallel with the libp2p pubsub channel for tip synchronization with out a problem.
+
+Recon itself is not backwards compatible with the current libp2p pubsub approach to synchronizing stream tips. However, the protocol could run in parallel with the pubsub channel to enable a period of interoperability with older nodes. Once a majority of nodes have been upgraded, the pubsub functionality should be removed. 
 
 
 ## Implementation

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -262,12 +262,32 @@ eventId = concatBytes(
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-### Why the properties in eventIds
+### Interest ranges
+
+At the core of the design of recon there is the concept of an interest range. Essentially a range is an ordered list of events across multiple streams. By using ranges to specify interest we allow nodes to have partial overlap with each other. This is useful because it removes the need for the network to have a uniform topology. Instead each node can chose to subscribe to as many or as few streams as they like to.
+
+
+
+* Why ranges?
+
+* Why subsets using "model"?
+* What about syncing individual streams?
+* 
+
+### EventId design
 
 * Why specific lengths?
 * Size overhead?
 
 With about a billon events per year as a target this is hundreds of gigabytes just for the keys without event accounting for the size of the events.
+
+* Other sort orders considered
+
+
+
+* Alt/custom peer discovery
+
+
 
 ### Motivation for the design
 

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -361,28 +361,26 @@ This implies that if we want to exclude the spam events there will be many holes
 
 
 
-## Appendix A: Associative Hash Function
+## Appendix A: Associative Hash Function (SumOfSha256s)
 
-
-
-* Explain the hash function
-* Explain the registration in the multicodec table
-
-### **Associative Hash Function (SumOfSha256s)**
-
-If we want to calculate the hash of a range of
-EventIDs without needing to visit all of the events
-we can use an associative hash function where the grouping
-of EventIDs is not relevant to the final hash.
+An associative hash function can simply be defined as a hash function that is associative:
 
 ```
-h((A, B), C) = h(A, (B, C))
+h(h(a, b), c) = h(a, h(b, c))
 ```
 
-e.g. use `sum(sha256(EventID) for EventID in Stream Set)`
-each node in the tree can store the associative hash of each
-sub tree along with its max and min we only need to recurse into that sub-tree if the range end is in the sub-tree. Since a range has only two ends, start and stop, we can calculate the associative hash by visiting only twice the depth of the tree number of nodes `2*log_b(n)`
-where b is the fanout and n is the number of EventIDs.
+ In Recon this is useful because we often want to compute the hash of all events between two given events. If we were to use a normal cryptographic hash function, it would be rather expensive to recompute this hash every time we split a range. It would also be a big overhead to keep a list of pre-computed hashes. Instead we can use an associative hash and store our events in a tree based on this "ahash". If we need to further split a range we simply recurse into the given sub-tree and join the ahashes we need from that level. We can compute the associative hash by traversing the depth of our tree only twice, e.g. `2*log_b(n)`,
+where b is the fanout and n is the number of eventIds.
+
+### SumOfSha256s
+
+In particular we define an associative hash function "SumOfSha256s" as simply the sum of sha2-256 hashes over leaf elements:
+
+```
+sum(sha256(eventId) for eventIds in stream set)
+```
+
+We also register the multihash code `0xXX` to be able to represent SumOfSha256s as a multihash.
 
 #### ahash
 
@@ -452,8 +450,6 @@ e.g. As the node size grows increase the probability of a boundary.
 This will reduce the odds of small nodes and large nodes
 in favor of target size nodes.
 
-
-
 ## Appendix C: Immutable object store
 
 A slight variant of the protocol can be used with a smart client and a dumb object store. Where all the computation takes place on the client and the storage just serves values for keys.
@@ -467,8 +463,6 @@ For syncing with an immutable object store we add CIDs to the intermediate nodes
 This protocol can be run against a object store. Instead of the remote deciding which segments to send a pre-built b-tree is stored in the object store. The client fetches the root of the b-tree. If the client has the same associative hash `sub-tree-ahash` for a subtree then it skips that subtree if it differs then it requests the b-tree node with `sub-tree-CID`. This continues recursively until all the events in the stored b-tree are synced down to the client.
 
 The use of synchronization against an object store may improve the experience of syncing a brand new node or a node that has been down for an extended period of time. The long down node could start by synchronizing against a weekly snapshot and only after that sync with live nodes getting the bulk of the dataset from the object store.
-
-
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -11,16 +11,13 @@ edited: 2023-05-24
 ## Simple Summary
 
 <!--Provide a simplified and layman-accessible explanation of the CIP.-->
-Recon is a sets reconciliation protocol to be used for synchronization of stream tips in ceramic network.
-Stream Sets bundle a number of streams together so the ceramic node with a common interest in those streams can synchronize efficiently.
-Once a set of streams is bundled into a stream set Recon can be used to sync ranges within those sets.
+Recon is a sets reconciliation protocol to be used for synchronization of stream events in ceramic network.
+Stream sets bundle a number of streams together, so that nodes with a common interest of streams can synchronize efficiently. Once a set of streams is bundled into a stream set, Recon can be used to sync ranges of events within those sets.
 
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-Stream Sets are bundles of streams that can be gossiped about as a group or in sub-ranges. In order to make ranges possible over a set of streams we need to define an order for the ranges to be over. e.g. `ceramic/<network>/<sep>/<EventID>` by assigning a recon key to each event we can define a range over the lexicographic sort of the sort keys. Now a node can advertise a have/want over a range `(first event ID, range_hash, last event ID)` If the node receiving the advertisements has the same set of events, then they will have the same hash and are in sync. If a node needs to advertise a new event it can send `(first_event_ID, hash, new_event_ID, hash, last_event_ID)` This tells any receiving node not only the new event ID but asserts all events in the range. If the receiving node has any additional or missing events in this range it is detected and can be synchronized.
-
-New nodes interested in a range of a stream set can be discovered in two ways. First if a node receives a have/want advertisement from a node it can add that node to its list of peers. Second nodes should advertise their wants to other known nodes in the network.
+Stream sets are bundles of streams that can be gossiped about as a group or in sub-ranges. In order to make ranges possible over a set of streams we need to define an order for the ranges to be over. By assigning an eventId of to event, we can define a range over the lexicographic sort of these eventIds. Now a node can advertise a have/want over a range `(first_event_id, range_hash, last_event_id)` If the node receiving the advertisements has the same set of events, then they will have the same hash and are in sync. If a node needs to advertise a new event it can send `(first_event_id, range_hash, new_event_id, range_hash, last_event_id)` This tells any receiving node not only the new eventId, but asserts all events in the range. If the receiving node has any additional or missing events in this range it is detected and can be synchronized. New nodes interested in a range of a stream set can be discovered in two ways. First, if a node receives a have/want advertisement from a node it can add that node to its list of peers. Second, nodes should advertise their wants to other known nodes in the network.
 
 
 ## Motivation

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -6,7 +6,7 @@ discussions-to: https://forum.ceramic.network/t/cip-124-recon-tip-synchronizatio
 status: Draft
 category: Networking
 created: 2023-01-18
-edited: 2023-05-24
+edited: 2023-05-25
 ---
 ## Simple Summary
 
@@ -22,37 +22,11 @@ Stream sets are bundles of streams that can be gossiped about as a group or in s
 
 ## Motivation
 <!--Motivation is critical for CIPs that want to change the Ceramic protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the CIP solves. CIP submissions without sufficient motivation may be rejected outright.-->
-Currently ceramic nodes broadcast updates to streams to every node in the network. This requires nodes to do work processing messages that they don’t care about. At the same time if a node missed the broadcast, it would not detect the missing stream unless it hears a later update or performs historical sync via the CAS ledger.
+Currently nodes broadcast updates to streams to every node in the network using a single libp2p pubsub topic. This incurs a lot of work on all nodes to process messages that they don’t necessarily care about. It also means that the throughput of the network is limited by the bandwidth, leading either to prioritizing high bandwidth nodes or greatly limiting the network throughput to support low bandwidth nodes. Furthermore, if a node missed the broadcast, it would not detect the missing stream events unless it hears a later update or uses some out of band synchronization protocol like "historical data sync" in ComposeDB that scans the Ethereum blockchain for anchor transactions.
 
-Recon could provide low to no overhead for nodes not synchronizing a given range of events, while retaining a high probability of getting the **latest** events from a stream shortly after any node has the events, and no need for remote connections at query time.
+Recon aims to provide low to no overhead for nodes with no overlap in interest, while retaining a high probability of getting the **latest** events from a stream shortly after any node has the events, without any need for remote connections at query time. By ceasing to publish updates in the pubsub channel and instead organizing them into a stream set, nodes interested in those streams can synchronize with each other without putting load on uninterested nodes in the network. A secondary goal of stream sets is to give a structure for sharding a stream set across mulitple nodes. By supporting the ability to synchronize only a sub-range of the stream set, the burden of storing, indexing, and retrieving streams can be sharded among nodes. 
 
-By pulling stream updates out of the main network channel into a stream set the nodes interested in those streams can synchronies with each other without putting load on uninterested nodes in the network. 
-
-These Stream Sets will likely be defined by a set of models that should be included in the Stream Set. They could also be defined by a set of models and controllers but the large and changing number of controllers requires more thought and is not proposed here. They could even be defined be an arbitrary function that filters streams for membership in/out of the set. e.g. Failed some spam filter.
-
-A stream also could potentially be included in more than one stream set if for example there are apps that want to sync every event across the entire network, they may want to form a stream set for all events that overlaps the narrower stream sets. We will start with one stream set that orders all the streams into a single stream set.
-
-The introduction of stream sets should lower the burden of running a node that is not interested in a stream set. This is due to sending the synchronization connections only to nodes that advertise an interest in a range. Stream set synchronizations could speed up the process of syncing all the historical events that are within a range by by detecting and backfilling missed updates with every synchronization update.
-
-A secondary goal of stream sets is to give a structure for sharding a stream set across ceramic nodes. By supporting an ability to synchronize only a sub-range of the stream set the burden of storing, indexing, and retrieving streams can be sharded among ceramic nodes.
-
-e.g.
-```
-Node1: [
-  "ceramic/<network>/<sep>/!", 
-  "ceramic/<network>/<sep>/i"
-]
-Node2: [
-  `ceramic/<network>/<sep>/i`,
-  `ceramic/<network>/<sep>/~`
-]
-```
-> note: The keys are base36 /`[0-9a-z]`/ so "`!`" is less then all keys and "`~`" is grater then all keys.
-
-Ceramic nodes also need to have a way to find the other nodes interested in the stream set so that they can synchronize with them.
-Recon will rely on gossiping about nodes existence and interests. When two nodes connect they can share lists of known nodes and their interests.
-
-By gossiping about ranges of streams ceramic nodes that are arbitrarily out of sync can synchronize all events of mutual interest. Nodes that are in sync or nearly in sync can send each other very little bandwidth. Nodes can avoid sending stream event announcements to nodes that have no interest in the stream ranges.
+Finally, nodes also need a way to find other nodes interested in the stream set or sub-range, so that they can synchronize with them. Recon relies on nodes gossiping their interest to peers, as well as keeping a list of their peers interest. This way nodes that are in sync, or nearly in sync, stay in sync with very little bandwidth. Nodes can also avoid sending stream event announcements to nodes that have no interest in the stream ranges. 
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature.-->

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -33,13 +33,13 @@ Finally, nodes also need a way to find other nodes interested in the stream set 
 
 ### Stream Set
 
-A stream set is defined by a value called `separator-key` which determines the sort ordering. A stream is considered to be part of a stream set if its InitEvent contains a header field that maps to the `separator-key`. The value of this field is referred to as the `separator-value`. For example, a stream set containing all *Models* and *Model Instance Documents* is defined with the *separator-key* `'model'`.
+A stream set is defined by a value called `sort-key` which determines the top level sort ordering. A stream is considered to be part of a stream set if its InitEvent contains a header field that is equal to the `sort-key`. The value of this field is referred to as the `sort-value`. For example, a stream set containing all *Models* and *Model Instance Documents* is defined with the *sort-key* `'model'`.
 
-You can think of a subset of this stream set as being all *Model Instance Documents* that share the same *Model* streamid as its *separator-key*, for example:
+You can think of a subset of this stream set as being all *Model Instance Documents* that share the same *Model* streamid as its *sort-key*, for example:
 
 ```js
-separator-key = 'model'
-separator-value = kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr
+sort-key = 'model'
+sort-value = kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr
 ```
 
 ### EventIds
@@ -60,7 +60,7 @@ Where `0xce` is the streamid multicode, `0x71` is the streamtype code for an eve
 eventIdBytes = EncodeDagCbor([ // ordered list not dict
   concatBytes(
     varint(networkId),
-    last16Bytes(separator-value),
+    last16Bytes(sort-value),
     last16Bytes(hash-sha256(stream-controller-did)),
     last8Bytes(init-event-cid)
   ),
@@ -74,7 +74,7 @@ Where:
 
 * `networkId` is a number as defined in the [networkIds table](../tables/networkIds.csv)
 
-* `separator-value` is based on a user provided value for *separator-key* and *separator-value*
+* `sort-value` is based on a user provided value for *sort-key* and *sort-value*
 * `stream-controller-did` is the controller DID of the stream this event belongs to
 * `init-event-cid` is the CID of the first, e.g. InitEvent, of the stream this event belongs to
 * `prevTimestamp` is the unix timestamp in most recent TimeEvent that came before this event. Note that for InitEvents this value is 0, and for TimeEvents this value is the timestamp of the TimeEvent that came before it.
@@ -242,9 +242,9 @@ eventId = concatBytes(
 )
 ```
 
-#### Discover peers using the same separator-value
+#### Discover peers using the same sort-value
 
-We can announce and discover peers in the same network and that are using the same separator-value by including the networkId and the separator-value in the eventId encoding.
+We can announce and discover peers in the same network and that are using the same sort-value by including the networkId and the sort-value in the eventId encoding.
 
 ```
 eventId = concatBytes(
@@ -253,7 +253,7 @@ eventId = concatBytes(
   EncodeDagCbor([
     concatBytes(
       varint(networkId),
-      last16Bytes(separator-value)
+      last16Bytes(sort-value)
     )
   ])
 )

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -353,13 +353,12 @@ WIP implementation in [rust-ceramic](https://github.com/3box/rust-ceramic/)
 
 ## Security Considerations
 <!--All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
-The associative hash functions are only secure if the node is asked to produce the EventIDs that hash to the SHAs that make up the SumOfShas associative hash.
 
-Recon works when you want to synchronize event that are contiguous in the key ordering.
-If a spammer is creating junk events each with there own controller did they will be spread uniformly throw the model.
-This implies that if we want to exclude the spam events there will be many holes and the representation will have many ranges. 
+Recon works well when you want to synchronize event that are contiguous in the key ordering. This opens up for the possibility of an attacker creating junk events where each of them have a separate controller DID to uniformly spread the events across a given stream set. This could significantly slow down the synchronization process, since if we want to exclude spam there would be many holes in the ranges. A possible mitigation for this could be to add more sophisticated forms of access control where only certain DIDs are allowed to write to certain ranges. Further options should be explored as well.
 
+The associative hash functions are only secure if the node is asked to produce the eventIds that hash to the SHAs that make up the SumOfShas associative hash.
 
+It's important that a node that receives a new eventId over recon synchronizes the data of this event and validates it before it relays this eventId to other peers. Otherwise invalid eventIds might be relayed
 
 ## Appendix A: Associative Hash Function (SumOfSha256s)
 

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -266,166 +266,76 @@ eventId = concatBytes(
 
 At the core of the design of recon there is the concept of an interest range. Essentially a range is an ordered list of events across multiple streams. By using ranges to specify interest we allow nodes to have partial overlap with each other. This is useful because it removes the need for the network to have a uniform topology. Instead each node can chose to subscribe to as many or as few streams as they like to.
 
+### Sort key and value
 
-
-* Why ranges?
-
-* Why subsets using "model"?
-* What about syncing individual streams?
-* 
+In order to group ComposeDB models together the *sort-key/value* is introduced to ensure that streams that use the same models end up close to each other in the recon range. This sorting functionality goes beyond ComposeDB however since users of recon can specify any sort-key. For example, with TileDocuments it could be useful to sort by *family* or *schema*. Future stream types could also leverage this sorting functionality in whichever way that makes sense to their use case. 
 
 ### EventId design
 
-* Why specific lengths?
-* Size overhead?
+An eventId has a very specific set of parameters and lengths, why do we use those specific values?
 
-With about a billon events per year as a target this is hundreds of gigabytes just for the keys without event accounting for the size of the events.
+* **networkId** - we need a way to separate different networks
+* **sort-value** and **stream-controller-did**- we use the last 16 bytes to provide sufficient amount of entropy in order to prevent malicious actors saturating the range
+* **stream-controller-did** - we use the sha256 hash of the DID in order to prevent malicious actors from simply picking a DID that overlaps with existing DIDs
+* **init-event-id** - we want to uniquely sort events from the same stream, but we don't need as much entropy here since the user has no incentive to make this value overlap
 
-* Other sort orders considered
+#### Other sort orders considered
 
+**Total time ordering of all anchored events in all streams.**
 
+- `<network>/<timeID>/<EventCID>`
+- **advantages**: we mainly get divergence is in recent events
+- **disadvantages:**
+  - Hard to shard, as you would load recent events in all streams
+  - Hard to subscribe to all events of a specific stream
+  - Hard to subscribe to all events of a specific controller 
 
-* Alt/custom peer discovery
+**Sort by StreamID lexicographic**
 
+- `<network>/<StreamID>/<EventID>`
+- **advantages**: simple to shard to StreamID ranges
+- **disadvantages**: subscribing to a model or controller would be many ranges
 
+**Sort by model_group/model/stream_group/StreamID/time/event**
 
-### Motivation for the design
+- `<network>/<model controller>/<model>/<stream controller>/<StreamID>/<event height>/<Event CID>`
+- **advantages**: models grouped by publisher, streams grouped by publisher, stream events in order
+- **disadvantages**: long keys
 
-Goals:
+**Z-order ([Hilbert Curve order](https://en.wikipedia.org/wiki/Z-order_curve))**
 
-- Low to no overhead for peers not subscribed to the stream being queried.
-- High probability of getting the ******latest****** tip (e.g. resilience to eclipse attacks etc.)
-- Low overhead for the querying peer (e.g. no requirement to connect to and query a massive number of peers)
+- `ceramic/<network>/< z(model, controller, time) >`
 
-Ceramic has a model where each ceramic node with an interest in a stream stores the contents of the stream. This means when a stream is created or updated each ceramic node should eventually hear about the new event and update its stream tip store.
+  <img src="../assets/cip-124/cube.png" alt="model controller time cube" style="zoom:75%;" />
 
-Currently this is being done by using a LibP2P PubSub channel. This works for low amounts of traffic while a node is up and listening to the channel. There are two main drawbacks of this method. One that if a node is down and misses an update it will not find out about the stream until the next update. Since the next update may never come nodes need to periodically run Historical Data Sync to discover events that it missed but are successfully anchored. Two that every node needs to process every update. Even if a node is only interested in a few low frequency models or controllers it still needs to be a large enough node to handle all updates and filter for the one that it is interested in.
+- **advantages:** 
 
-The LibP2P PubSub channel is meant for data that has only a limited time of interest. It only remembers messages for a short time then expires them. If a node gets very behind in processing the incoming message queue it can re-broadcast messages after the other nodes have forgotten it causing the message to be redelivered to all nodes in the channel. Since the node is way behind it will see its own message later and re-re-broadcast it. This infinitely looping message can slow down other nodes that start re-broadcast messages leading to a network storm. A single slow, or malicious, node can harm the entire network’s ability to use the channel. Event update lost in the storm may not be picked up until Historical Data Sync runs.
+  - Clustering by model, controller, and time
 
-By switching to a set reconciliation gossip protocol (Recon) we solve both problems.
+- **disadvantages:**
 
-One, if a node missed a stream update it will detect that the node it is synchronizing with has an event that it does not. A node could go down for years and when it rejoined the network it would just sync back to the current state.
+  - Complexity
+  - All three dimensions have few ranges but none are single range.
 
-Two, if a node is only interested in a subset of the streams, it can synchronize only the ranges that it cares about. A single node that is too slow to keep up with the number of streams it is interested in will start a synchronization that will never finish but will only cause load on the node that it is synchronizing with and not cause a network wide disruption.
+### Peer discovery
 
----
+The peer discovery mechanism described in the spec serves two cases: (1) when the network is still small, discovering all nodes in the network is good and preferred to build complete peer lists, (2) when the network grows, peer discovery per sort-key provides the advantage that nodes only need to connect to nodes that they know have an overlap in interest range. The overlap might still not be 100% however. So in the future there might be new approaches needed to make peer discovery more effective.
+
+An alternative approach to peer discovery where peers simply shared their known peers with other peers in the network was also explored. However, the DHT approach was chosen as it is simpler to implement and already known to work.
 
 ### Alternate designs considered and related work
 
-Hash graph stile gossip
+#### Hash graph style gossip
 
 Each node collects the event that occur on that node into an update block. Each time a node receives an update block from a different node it puts the CID of its previous block and the incoming block at the end of the current block to finish that update block and starts a new one. Then send the finished block to a random ceramic node. Since each block has the CID of two earlier blocks if can follow back to the beginning of time.
 
 This was rejected since it did not allow for a node to follow a limited subset of the streams.
 
-Predicated LibP2P PubSub channels
+#### Predicated LibP2P PubSub channels
 
-Can we change LibP2P PubSub to only send the events that a node cares about to limit the number of messages a node needs to process.
+We could change LibP2P PubSub to only send the events that a node cares about to limit the number of messages a node needs to process, based on a predicate. If we can use a TTE(Time To Expire) as part of the predicate we may also be able to solve the network storm problem.
 
-If we can use a TTE(Time To Expire) as part of the predicate we may be able to solve the network storm problem.
-
-This was rejected because it does not solve the missed messages problem.
-
-We still plan to revisit this in the future
-
-#### **DHT for interest discovery**
-In order to discover other ceramic nodes that have overlapping interest
-a node could announce itself in the DHT as interested in a model.
-the dht key would be derived by `separatorKey` and `separatorValue`
-
-```
-key =  are set, use `partition = hash(separatorKey | separatorValue)`
-```
-
----
-#### **Stream set sort order**
-example lexicographical sort order
-```
-ceramic/<network>/<partition_key>/<EventID>
-```
-The `partition_key` would be defined for a specific stream set.
-
-For the default stream set with all streams we could partition on`stream type`, `model`, `controller`, `time` , or something else using a partition key? We could even map multiple dimensions into a single partition key and then partition based on the calculated partition key.
-![model controller time cube](../assets/cip-124/cube.png)
-
-#### **What are the sorting orders that make sense?**
-- Total time ordering of all anchored events in all streams.
-    - `ceramic/<network>/<timeID>/<EventID>`
-    - advantages: most divergence is in recent events
-    - disadvantages:
-      - hard to shard as most load is recent events,
-      - hard to follow a stream,
-      - hard to follow a controller 
-- Sort by StreamID lexicographic
-    - `ceramic/<network>/<StreamID>/<EventID>`
-    - advantages: simple to shard to StreamID ranges
-    - disadvantages: following a model or controller would be many ranges
-- Sort by model/StreamID
-    - `ceramic/<network>/<model>/<StreamID>/<event height><Event CID>`
-    - advantages:
-      - following a models is a single range
-    - disadvantages:
-      - following a controllers is a many ranges
-
-- Sort by model_group/model/stream_group/StreamID/time/event
-    - `ceramic/<network>/<model controller>/<model>/<stream controller>/<StreamID>/<event height>/<Event CID>`
-    - advantages: models grouped by publisher, streams grouped by publisher, stream events in order
-    - disadvantages: long keys
-
-- Z-order (Hilbert Curve order)
-    - `ceramic/<network>/< z(model, controller, time) >`
-    - advantages: 
-      - clustering by model, controller, and time
-    - disadvantages:
-      - complexity
-      - all three dimensions have few ranges but none are single range.
-    - notes:
-      - [https://youtu.be/YLVkITvF6KU](https://youtu.be/YLVkITvF6KU)
-      - [https://en.wikipedia.org/wiki/Z-order_(curve)](https://en.wikipedia.org/wiki/Z-order_(curve))
-      - e.g.
-        1. hash the model
-        2. hash the controler
-        3. timestamp
-        3. interleave the bytes of the hash M00:C00:T00:M01:C01:T00:...
-        4. cluster into chunks e.g. 64MiB files
-
-example
-
-partition_key = model_controller/model/stream_controller/stream/height/event
-```
-did:key:z6Mkq1r4LAsQTjCN7EBTnGf7DorL28aZ4eb6akcLwJSwygBt/
-kjzl6hvfrbw6c5sffjlmczg8nmbk8kwu9lmgiqfd9bxi7pxp14u674cuxp09szz/
-did:key:z6Mkq1r4LAsQTjCN7EBTnGf7DorL28aZ4eb6akcLwJSwygBt/
-kjzl6kcym7w8y7hyovnujm2zbxa57z0z0yhmnlsx9qe4gtyurcbg6z2aw967s0d/
-0/
-bafyreidx27tvivoh4hre4xrjnqprntsbmvsoujydcr5cinu4b2exqjeeue
-```
-
-```
-did:key:z6Mkq1r4LAsQTjCN7EBTnGf7DorL28aZ4eb6akcLwJSwygBt/
-kjzl6hvfrbw6c5sffjlmczg8nmbk8kwu9lmgiqfd9bxi7pxp14u674cuxp09szz/
-did:key:z6Mkq1r4LAsQTjCN7EBTnGf7DorL28aZ4eb6akcLwJSwygBt/
-kjzl6kcym7w8y7hyovnujm2zbxa57z0z0yhmnlsx9qe4gtyurcbg6z2aw967s0d/
-1/
-bagcqcerand3n6q246mfo2v7d6i7aacpxlfnfprhyid5rcnej2bawqnlnsogq
-```
-
-this would be about 300 chars so we may want to abbreviate
-model_controller/model/stream_controller/stream/height/event
-`JSwygB/xp09sz/JSwygB/w967s0/0/bafyreidx27tvivoh4hre4xrjnqprntsbmvsoujydcr5cinu4b2exqjeeue`
-`JSwygB/xp09sz/JSwygB/w967s0/1/bagcqcerand3n6q246mfo2v7d6i7aacpxlfnfprhyid5rcnej2bawqnlnsogq`
-
-Model_controller keeps model published by the same model creator together.
-Model keeps all the documents of a model together.
-Stream_controller keeps streams published by the same stream creator together.
-StreamID keeps the updates to a stream together.
-Height keeps the updates to a stream in order.
-
-Since interests are expressed as interest ranges a ceramic node interested in a set of models relevant to an application
-will be able to subscribe with a small number of ranges. The number of ranges will be on the order of the number of
-model_controllers they are interested in. If application developers publish all the models for their application using
-a single controller then the models will be efficient to sync as a group.
+This approach was rejected because it does not solve the missed messages problem.
 
 ## Backwards Compatibility
 <!--All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility section may be rejected outright.-->


### PR DESCRIPTION
Cleans up copy outside of the spec section.

- [x] Summary
- [x] Abstract
- [x] Motivation 
- [x] Rationale
- [x] Backwards compat.
- [x] Implementation
- [x] Security cons.
- [x] Appendix

In addition I also renamed *separator-key/value* to *sort-key/value*.