### PR TITLE
Update old CIPs to appropriate statuses

### DIFF
--- a/CIPs/cip-110.md
+++ b/CIPs/cip-110.md
@@ -3,7 +3,7 @@ cip: 110
 title: Ceramic Anchor Contract
 author: Sergey Ukustov <sergey@ukstv.me>
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/110
-status: Review
+status: Final
 category: RFC
 created: 2021-10-14
 edited: 2023-05-24

--- a/CIPs/cip-120.md
+++ b/CIPs/cip-120.md
@@ -3,7 +3,7 @@ cip: 120
 title: Multiple Pubsub Topics
 author: Joel Thorstensson <joel@3box.io>
 discussions-to: https://forum.ceramic.network/t/cip-120-multiple-pubsub-topics/
-status: Review
+status: Draft
 category: Core
 created: 2022-12-13
 edited: 2022-12-13

--- a/CIPs/cip-5.md
+++ b/CIPs/cip-5.md
@@ -3,7 +3,7 @@ cip: 5
 title: Streamtypes
 author: Michael Sena (@michaelsena), Joel Thorstensson (@oed), Janko Simonovic
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/37
-status: Review
+status: Final
 category: RFC
 created: 2020-06-23
 edited: 2020-09-24

--- a/CIPs/cip-7.md
+++ b/CIPs/cip-7.md
@@ -3,7 +3,7 @@ cip: 7
 title: CAIP-10 Link
 author: Joel Thorstensson (@oed), Michael Sena (@michaelsena)
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/15
-status: Review
+status: Final
 category: RFC
 created: 2020-07-24
 edited: 2020-07-24

--- a/CIPs/cip-8.md
+++ b/CIPs/cip-8.md
@@ -3,7 +3,7 @@ cip: 8
 title: Tile Document
 author: Joel Thorstensson (@oed)
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/56
-status: Review
+status: Final
 category: RFC
 created: 2020-07-22
 edited: 2020-07-22


### PR DESCRIPTION
It could be confusing for people to see multiple old CIPs being in review still. There's really no good reason to keep them there. They should either be made final and updated through subsequent CIP, or moved back to draft stage.

**Changes:**
* cip-5, streamtypes: review -> final
* cip-7, caip10-link: review -> final
* cip-8, tile document: review -> final
* cip-110, anchor contract: review -> final
* cip-120, multiple pubsub topics: review -> draft
