### PR TITLE
Remove type on the rendered webpage

### DIFF
--- a/_layouts/cip.html
+++ b/_layouts/cip.html
@@ -36,15 +36,9 @@ layout: default
     </td>
     </tr>
     <tr>
-      <th>Type</th>
-      <td>{{ page.type | xml_escape }}</td>
-    </tr>
-    {% if page.category != undefined %}
-    <tr>
       <th>Category</th>
       <td>{{ page.category | xml_escape }}</td>
     </tr>
-    {% endif %}
     <tr>
       <th>Created</th>
       <td>{{ page.created | xml_escape }}</td>


### PR DESCRIPTION
Since #130 we no longer use the `type` field on CIPs. This PR removes them from the rendered webpage at https://cips.ceramic.network