### PR TITLE
CIP: Ceramic API

### DIFF
--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -143,7 +143,7 @@ Get the raw IPLD data of a set of events given an array of eventids. This includ
 
 **Returns:**
 
-- *events* <string> - a base64 encoded CAR file containing the events
+- *events* <string> - a base64 encoded CAR file containing the event blocks
 
 ---
 

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -1,0 +1,200 @@
+---
+cip: 137
+title: Ceramic API
+author: Danny Browning <dbrowning@3box.io>, Nathaniel Cook <nathaniel@3box.io>, Aaron Goldman <aaron@3box.io>, Joel Thorstensson <joel@3box.io>
+discussions-to: <URL to a topic under the CIP category on the Ceramic forum: https://forum.ceramic.network/c/cips>
+status: Draft
+category: Interface
+created: 2023-05-28
+edited: 2023-05-28
+requires: 124
+---
+
+
+## Simple Summary
+<!--Provide a simplified and layman-accessible explanation of the CIP.-->
+An API for reading and writing events on Ceramic event streams.
+
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+TODO
+
+
+## Motivation
+<!--Motivation is critical for CIPs that want to change the Ceramic protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the CIP solves. CIP submissions without sufficient motivation may be rejected outright.-->
+TODO
+
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature.-->
+
+This is a work in progress specification that introduces a JSON-RPC interface for interacting directly with event streams on a node.
+
+
+
+### `ceramic_subscribe`
+
+This method tells the Ceramic node to subscribe to a given subset of streams. A stream subset is defined as `ceramic://*?<separator-key>=<separator-value>`, where *separator-key* describes a field in the header of the InitEvent of a stream,  and *separator-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
+
+Once subscribed the Ceramic node will use the Recon protocol to keep in sync with other nodes subscribed to this stream set.
+
+Active subscriptions need to be persisted. Or can be stateless somehow? (Ask Nathaniel)
+
+**Params:**
+
+- *ceramicUrl* <string> - the Ceramic URL to subscribe to
+- *options* <object> - options for the subscription
+    - *rangeNumber* <integer> - splits the stream set space into the given number of ranges
+    - *rangeIndex* <integer> - subscribes only to the given range index
+
+**Returns:**
+
+- *range* <Array<string>> - a Recon message, representing the latest state of the range described by the subscription request. In the form of `[eventid, ahash, eventid]`
+
+---
+
+### `ceramic_unsubscribe`
+
+This method tells the Ceramic node to unsubscribe from a given stream set.
+
+**Params:**
+
+- *ceramicUrl* <string> - the Ceramic URL to unsubscribe from
+
+**Returns:**
+
+- *success* <boolean> - true if the request was successful
+
+---
+
+### `ceramic_listSubscriptions`
+
+List stream subsets that this node is subscribed to.
+
+**Returns:**
+
+* *subscriptions* <array<object>> - a list of all subscriptions
+  * *ceramicUrl* <string> - the Ceramic URL of the subscription
+  * *rangeNumber* <integer> - the range split of the subscription
+  * *rangeIndex* <integer> - the range index of the subscription
+
+---
+
+### `ceramic_poll`
+
+Used by the client to poll for new events. This method uses the Ceramic nodes local ordering of events within the given *streamid*The Ceramic node constructs this ordering based on the order in which it received the events. If you want the global ordering of events you can use the `ceramic_recon` method.
+
+**Params:**
+
+- *ceramicUrl* <string> - the Ceramic URL to poll for
+- *eventOffset* <integer> - the number of events already consumed
+- *duration* <integer> - the amount of time, in seconds, to wait for new data
+
+**Returns:**
+
+- *events* <array<object>> - the list of events
+    - *eventId* <string> - the id of the event
+    - *id* <string> - CID of the InitEvent for this stream
+    - *prev* <array<string>> - CIDs of previous hash linked events
+    - *header* <object> - header for the event
+    - *data* <object> - the data of the event
+    - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
+- *eventOffset* <integer> - the number of events consumed
+
+---
+
+### `ceramic_recon`
+
+Interact with the Ceramic node using the Recon protocol directly. This allows you to have greater control over the data you consume, but you have to be able to run the Recon algorithm client side.
+
+**Params:**
+
+- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+
+**Returns:**
+
+- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+
+---
+
+### `ceramic_reconPoll`
+
+Same as `ceramic_recon`, but waits for *duration* amount of time in case any new events arrives at the node during this time.
+
+**Params:**
+
+- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+- *duration* <integer> - the amount of time, in seconds, to wait for new data
+
+**Returns:**
+
+- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+
+---
+
+### `ceramic_getRawEvents`
+
+Get the raw IPLD data of a set of events given an array of eventids.
+
+**Params:**
+
+- *[eventid]* <array<string>> - the events to fetch
+
+**Returns:**
+
+- *events* <string> - a base64 encoded CAR file containing the events
+
+---
+
+### `ceramic_addRawEvent`
+
+Add an event to a stream.
+
+**Params:**
+
+- *event* <string> - a base64 encoded CAR file containing the event
+
+**Returns:**
+
+- *success* <boolean> - true if the event was added correctly
+
+---
+
+### `ceramic_addEvent`
+
+Convenience method for adding an event by only submitting a JWT.
+
+Only possible once we’ve migrated to use *Varsig* and can create events as plain signed JWTs.
+
+**Params:**
+
+- *event* <string> - a jwt containing the event
+
+**Returns:**
+
+- *success* <boolean> - true if the event was added correctly
+
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+TODO
+
+
+## Backwards Compatibility
+<!--All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility section may be rejected outright.-->
+TODO
+
+
+## Implementation
+<!--The implementations must be completed before any CIP is given status "Final", but it need not be completed before the CIP is accepted.-->
+TODO
+
+
+## Security Considerations
+<!--All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+TODO
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -2,11 +2,11 @@
 cip: 137
 title: Ceramic API
 author: Danny Browning <dbrowning@3box.io>, Nathaniel Cook <nathaniel@3box.io>, Aaron Goldman <aaron@3box.io>, Joel Thorstensson <joel@3box.io>
-discussions-to: <URL to a topic under the CIP category on the Ceramic forum: https://forum.ceramic.network/c/cips>
+discussions-to: https://forum.ceramic.network/t/cip-137-ceramic-api/
 status: Draft
 category: Interface
 created: 2023-05-28
-edited: 2023-05-28
+edited: 2023-06-01
 requires: 124
 ---
 
@@ -18,7 +18,7 @@ An API for reading and writing events on Ceramic event streams.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-TODO
+This CIP introduces a JSON-RPC interface that can be used to subscribe to a number of streams inside of an interest range, and write new events to these streams. The API exposes two main ways of retrieving events. A simple method that uses the nodes local ordering of events to retrieve events by simply keeping track of a single vector client side. More advanced users can use a simplified version of the [Recon](https://cips.ceramic.network/CIPs/cip-124) protocol to retrieve events in their logical order.
 
 
 ## Motivation
@@ -35,7 +35,7 @@ This is a work in progress specification that introduces a JSON-RPC interface fo
 
 ### `ceramic_subscribe`
 
-This method tells the Ceramic node to subscribe to a given interest range of streams. A interest range is defined as `ceramic://*?<separator-key>=<separator-value>`, where *separator-key* describes a field in the header of the InitEvent of a stream, and *separator-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
+This method tells the Ceramic node to subscribe to a given interest range of streams. A interest range is defined as `ceramic://*?<sort-key>=<sort-value>`, where *sort-key* describes a field in the header of the InitEvent of a stream, and *sort-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
 
 Once subscribed the Ceramic node will use the Recon protocol to keep in sync with other nodes subscribed to this interest range.
 
@@ -83,7 +83,7 @@ List interest ranges that this node is subscribed to.
 
 ### `ceramic_poll`
 
-Used by the client to poll for new events. This method uses the Ceramic nodes local ordering of events within the given *streamid*The Ceramic node constructs this ordering based on the order in which it received the events. If you want the global ordering of events you can use the `ceramic_recon` method.
+Used by the client to poll for new events. This method uses the Ceramic node's local ordering of events within the given *streamid*The Ceramic node constructs this ordering based on the order in which it received the events. If you want the global ordering of events you can use the `ceramic_recon` method.
 
 **Params:**
 
@@ -178,22 +178,25 @@ Only possible once we’ve migrated to use *Varsig* and can create events as pla
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
-TODO
+
+The choice of using json-rpc enables the API to work over multiple different transports. For example, HTTP, web sockets, or event the iframe postMessage api. The latter could be useful in the future if one want's to run a node inside of an iframe.
+
+There are two main ways of polling for new events. Using recon and a more simple poll. This enables advanced developers to get full control with recon, while a simple poll API based on a single event counter is much easier to use for most developers. The disadvantage of the latter is that events will be received in the order that the node received them, not in the global order of the network.
 
 
 ## Backwards Compatibility
 <!--All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility section may be rejected outright.-->
-TODO
+The Ceramic API provides a new way of interacting with event streams. The main backwards compatibility consideration is that the ComposeDB implementation in js-ceramic would need to be refactored, but this should not imply any major breaking changes.
 
 
 ## Implementation
 <!--The implementations must be completed before any CIP is given status "Final", but it need not be completed before the CIP is accepted.-->
-TODO
+No implementation yet. Planned in [rust-ceramic](https://github.com/3box/rust-ceramic/)
 
 
 ## Security Considerations
 <!--All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
-TODO
+Currently this API is not designed to be exposed to the public internet. Instead it's intended for internal use, e.g. consumed by a ComposeDB node that in turn has a  more strict access controlled API open to the internet. 
 
 
 ## Copyright

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -23,7 +23,7 @@ TODO
 
 ## Motivation
 <!--Motivation is critical for CIPs that want to change the Ceramic protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the CIP solves. CIP submissions without sufficient motivation may be rejected outright.-->
-TODO
+In order to enable databases other than ComposeDB to be built on top of Ceramic, an API to read and write directly on event streams is needed. This also enables developers to get direct access to the event streams underlaying ComposeDB.
 
 
 ## Specification
@@ -35,11 +35,11 @@ This is a work in progress specification that introduces a JSON-RPC interface fo
 
 ### `ceramic_subscribe`
 
-This method tells the Ceramic node to subscribe to a given subset of streams. A stream subset is defined as `ceramic://*?<separator-key>=<separator-value>`, where *separator-key* describes a field in the header of the InitEvent of a stream,  and *separator-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
+This method tells the Ceramic node to subscribe to a given interest range of streams. A interest range is defined as `ceramic://*?<separator-key>=<separator-value>`, where *separator-key* describes a field in the header of the InitEvent of a stream, and *separator-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
 
-Once subscribed the Ceramic node will use the Recon protocol to keep in sync with other nodes subscribed to this stream set.
+Once subscribed the Ceramic node will use the Recon protocol to keep in sync with other nodes subscribed to this interest range.
 
-Active subscriptions need to be persisted. Or can be stateless somehow? (Ask Nathaniel)
+Active subscriptions need to be persisted. Or can be stateless somehow? (Nathaniel to share more thoughts here)
 
 **Params:**
 
@@ -56,7 +56,7 @@ Active subscriptions need to be persisted. Or can be stateless somehow? (Ask Nat
 
 ### `ceramic_unsubscribe`
 
-This method tells the Ceramic node to unsubscribe from a given stream set.
+This method tells the Ceramic node to unsubscribe from a given interest range.
 
 **Params:**
 
@@ -70,7 +70,7 @@ This method tells the Ceramic node to unsubscribe from a given stream set.
 
 ### `ceramic_listSubscriptions`
 
-List stream subsets that this node is subscribed to.
+List interest ranges that this node is subscribed to.
 
 **Returns:**
 
@@ -133,9 +133,9 @@ Same as `ceramic_recon`, but waits for *duration* amount of time in case any new
 
 ---
 
-### `ceramic_getRawEvents`
+### `ceramic_exportRawEvents`
 
-Get the raw IPLD data of a set of events given an array of eventids.
+Get the raw IPLD data of a set of events given an array of eventids. This includes all IPLD blocks for this particular event, but no data from the previous events, e.g. DataEvents include signature envelope, event, and potentially detached payload, while TimeEvents include their entire merkle tree witness.
 
 **Params:**
 
@@ -147,7 +147,7 @@ Get the raw IPLD data of a set of events given an array of eventids.
 
 ---
 
-### `ceramic_addRawEvent`
+### `ceramic_putRawEvent`
 
 Add an event to a stream.
 
@@ -161,7 +161,7 @@ Add an event to a stream.
 
 ---
 
-### `ceramic_addEvent`
+### `ceramic_putEvent`
 
 Convenience method for adding an event by only submitting a JWT.
 


### PR DESCRIPTION
This is an early draft of what could become the Ceramic API. An API that enables developers to read and write events directly to event streams.

### [Discussion forum thread](https://forum.ceramic.network/t/cip-137-ceramic-api/1153)