### PR TITLE
feat: Add a multicode to ahash

### DIFF
--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -379,7 +379,7 @@ In particular we define an associative hash function "SumOfSha256s" as simply th
 sum(sha256(eventId) for eventIds in stream set)
 ```
 
-We also register the multihash code **`0xce12`** to be able to represent SumOfSha256s as a multihash.
+We also register the multihash code **`0x7012`** to be able to represent SumOfSha256s as a multihash.
 
 #### ahash
 

--- a/CIPs/cip-124.md
+++ b/CIPs/cip-124.md
@@ -379,7 +379,7 @@ In particular we define an associative hash function "SumOfSha256s" as simply th
 sum(sha256(eventId) for eventIds in stream set)
 ```
 
-We also register the multihash code `0xXX` to be able to represent SumOfSha256s as a multihash.
+We also register the multihash code **`0xce12`** to be able to represent SumOfSha256s as a multihash.
 
 #### ahash
 


### PR DESCRIPTION
Suggests that we register `0x7012` in the [multicode table](https://github.com/multiformats/multicodec/blob/master/table.csv). This means that there will be a total of 4 extra byte per ahash we represent in Recon:

* 2 bytes for `varint(0x7012)`
* 1 byte for hash length

