### PR TITLE
Feat: Ceramic API using OpenAPI

### DIFF
--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -57,6 +57,7 @@ This endpoint will respond as soon as the node knows about new events, given the
 * *eventOffset* <integer> - the number of events already consumed
 * *duration* <integer> - the amount of time, in seconds, to wait for a response
 
+
 #### Returns:
 
 There are two different content types supported as return value, as specified by the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) http header.
@@ -157,6 +158,7 @@ This content type returns a json representation of the events requested. Note th
   - *header* <object> - header for the event
   - *data* <object> - the data of the event
   - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
+
 
 **CAR file:**
 

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -259,7 +259,7 @@ The Ceramic API provides a new way of interacting with event streams. The main b
 
 ## Implementation
 <!--The implementations must be completed before any CIP is given status "Final", but it need not be completed before the CIP is accepted.-->
-No implementation yet. Planned in [rust-ceramic](https://github.com/3box/rust-ceramic/)
+A partial implementation exists in [rust-ceramic](https://github.com/3box/rust-ceramic/). It currently implements the following [OpenAPI schema](https://github.com/3box/rust-ceramic/blob/main/api/ceramic.yaml).
 
 
 ## Security Considerations

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -59,7 +59,7 @@ This endpoint will respond as soon as the node knows about new events, given the
 
 #### Returns:
 
-There are two different content types supported as return value. 
+There are two different content types supported as return value, as specified by the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) http header.
 
 **JSON:**
 
@@ -142,6 +142,8 @@ Retrieve events given an array of eventids.
 
 #### Returns:
 
+There are two different content types supported as return value, as specified by the [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) http header.
+
 **JSON:**
 
 Content-Type:  `application/json`
@@ -210,9 +212,11 @@ Only possible once we’ve migrated to use *Varsig* and can create events as pla
 
 #### Returns:
 
+
+
 **JSON:**
 
-- *success* <boolean> - true if the event was added correctly
+- *eventid* <string> - the eventId of this event
 
 
 

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -1,7 +1,7 @@
 ---
 cip: 137
 title: Ceramic API
-author: Danny Browning <dbrowning@3box.io>, Nathaniel Cook <nathaniel@3box.io>, Aaron Goldman <aaron@3box.io>, Joel Thorstensson <joel@3box.io>
+author: Danny Browning <dbrowning@3box.io>, Nathaniel Cook <nathaniel@3box.io>, Aaron Goldman <aaron@3box.io>, Joel Thorstensson <joel@3box.io>, Spencer T Brody <spencer@3box.io> 
 discussions-to: https://forum.ceramic.network/t/cip-137-ceramic-api/
 status: Draft
 category: Interface
@@ -18,187 +18,223 @@ An API for reading and writing events on Ceramic event streams.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-This CIP introduces a JSON-RPC interface that can be used to subscribe to a number of streams inside of an interest range, and write new events to these streams. The API exposes two main ways of retrieving events. A simple method that uses the nodes local ordering of events to retrieve events by simply keeping track of a single vector client side. More advanced users can use a simplified version of the [Recon](https://cips.ceramic.network/CIPs/cip-124) protocol to retrieve events in their logical order.
+This CIP introduces a REST API that can be used to subscribe to a number of streams inside of an interest range, and write new events to these streams. The API exposes two main ways of retrieving events. A simple method that uses the nodes local ordering of events to retrieve events by simply keeping track of a single vector client side. More advanced users can use a simplified version of the [Recon](https://cips.ceramic.network/CIPs/cip-124) protocol to retrieve events in their logical order.
 
 
 ## Motivation
 <!--Motivation is critical for CIPs that want to change the Ceramic protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the CIP solves. CIP submissions without sufficient motivation may be rejected outright.-->
-In order to enable databases other than ComposeDB to be built on top of Ceramic, an API to read and write directly on event streams is needed. This also enables developers to get direct access to the event streams underlaying ComposeDB.
+In order to enable services and databases other than ComposeDB to be built on top of Ceramic, an API to read and write directly on event streams is needed. This also enables developers to get direct access to the event streams underlaying ComposeDB.
 
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature.-->
 
-This is a work in progress specification that introduces a JSON-RPC interface for interacting directly with event streams on a node.
+This specification introduces a REST API for interacting directly with event streams on a node.
 
 
 
-### `ceramic_subscribe`
+### GET `/ceramic/subscribe/{streamid}`
 
-This method tells the Ceramic node to subscribe to a given interest range of streams. A interest range is defined as `ceramic://*?<sort-key>=<sort-value>`, where *sort-key* describes a field in the header of the InitEvent of a stream, and *sort-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
+This endpoint is called to subscribe to new events in a given interest range. This endpoint uses the node’s local ordering of events within the given range, constructed in the order in which the node received the events. If you want the global ordering of events you can use the *recon* endpoint. 
 
-Once subscribed the Ceramic node will use the Recon protocol to keep in sync with other nodes subscribed to this interest range.
+The range is normally defined as `ceramic://*?<sort-key>=<sort-value>`, where *sort-key* describes a field in the header of the InitEvent of a stream, and *sort-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
 
-Active subscriptions need to be persisted. Or can be stateless somehow? (Nathaniel to share more thoughts here)
+This endpoint will respond as soon as the node knows about new events, given the *eventOffset*, or when *duration* amount of seconds has passed.
 
-**Params:**
+#### Example:
 
-- *ceramicUrl* <string> - the Ceramic URL to subscribe to
-- *options* <object> - options for the subscription
-    - *ctrlRangeStart* <string> - hex encoded string describing the start of the range of controllers to sync (defaults to `0x0000000000000000`)
-    - *ctrlRangeEnd* <string> - hex encoded string describing the end of the range of controllers to sync (defaults to `0xffffffffffffffff`)
+```
+/ceramic/subscribe/*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr&ctrlRangeStart=0x0000000000000000&ctrlRangeEnd=0xffffffffffffffff&eventOffset=123&duration=1000
+```
 
-**Returns:**
+#### Parameters:
 
-- *range* <Array<string>> - a Recon message, representing the latest state of the range described by the subscription request. In the form of `[eventid, ahash, eventid]`
+* *streamid* <string> - the stream to subscribe to (Normally `*` is used to subscribe to sets of streams)
 
----
+* *{sort-key}* <string> - the *sort-key* and *sort-value* to subscribe to (e.g. `model` and `kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr` respectively)
+* *ctrlRangeStart* <string> - hex encoded string describing the start of the range of controllers to sync (defaults to `0x0000000000000000`)
+* *ctrlRangeEnd* <string> - hex encoded string describing the end of the range of controllers to sync (defaults to `0xffffffffffffffff`)
+* *eventOffset* <integer> - the number of events already consumed
+* *duration* <integer> - the amount of time, in seconds, to wait for a response
 
+#### Returns:
 
+There are two different content types supported as return value. 
 
-### `ceramic_unsubscribe`
+**JSON:**
 
-This method tells the Ceramic node to unsubscribe from a given interest range.
+Content-Type:  `application/json`
 
-**Params:**
-
-- *ceramicUrl* <string> - the Ceramic URL to unsubscribe from
-- *options* <object> - options for the subscription
-  - *ctrlRangeStart* <string> - hex encoded string describing the start of the range of controllers to sync (defaults to `0x0000000000000000`)
-  - *ctrlRangeEnd* <string> - hex encoded string describing the end of the range of controllers to sync (defaults to `0xffffffffffffffff`)
-
-**Returns:**
-
-- *success* <boolean> - true if the request was successful
-
----
-
-
-
-### `ceramic_listSubscriptions`
-
-List interest ranges that this node is subscribed to.
-
-**Returns:**
-
-* *subscriptions* <array<object>> - a list of all subscriptions
-  * *ceramicUrl* <string> - the Ceramic URL of the subscription
-  * *ctrlRangeStart* <string> - hex encoded string describing the start of the range of controllers to sync (defaults to `0x0000000000000000`)
-  * *ctrlRangeEnd* <string> - hex encoded string describing the end of the range of controllers to sync (defaults to `0xffffffffffffffff`)
-
----
-
-
-
-### `ceramic_poll`
-
-Used by the client to poll for new events. This method uses the Ceramic node's local ordering of events within the given *streamid*The Ceramic node constructs this ordering based on the order in which it received the events. If you want the global ordering of events you can use the `ceramic_recon` method.
-
-**Params:**
-
-- *ceramicUrl* <string> - the Ceramic URL to poll for
-- *eventOffset* <integer> - the number of events already consumed
-- *duration* <integer> - the amount of time, in seconds, to wait for new data
-
-**Returns:**
+This content type returns a json representation of the events received. Note that this is just a representation of the event content, full verifiability is not retained.
 
 - *events* <array<object>> - the list of events
-    - *eventId* <string> - the id of the event
-    - *id* <string> - CID of the InitEvent for this stream
-    - *prev* <array<string>> - CIDs of previous hash linked events
-    - *header* <object> - header for the event
-    - *data* <object> - the data of the event
-    - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
+  - *eventId* <string> - the id of the event
+  - *id* <string> - CID of the InitEvent for this stream
+  - *prev* <array<string>> - CIDs of previous hash linked events
+  - *header* <object> - header for the event
+  - *data* <object> - the data of the event
+  - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
 - *eventOffset* <integer> - the number of events consumed
 
----
 
 
+**CAR file:**
 
-### `ceramic_recon`
+Content-Type:  `application/vnd.ipld.car`
 
-Interact with the Ceramic node using the Recon protocol directly. This allows you to have greater control over the data you consume, but you have to be able to run the Recon algorithm client side.
+This content types returns the underlaying IPLD data structure of the event streams encoded as a CAR file. This data can be used to trustlessly verify the integrity of the event stream. 
 
-**Params:**
+The root object of the CAR file is a *SubscriptionResult* which contains an array of *EvenIds* the new *eventOffset*. The CAR file also includes all *Event* objects, corresponding to the eventids in the subscription result.
 
-- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+It's worth noting that an *EventId* always includes the CID of its *Event*.
 
-**Returns:**
+```verilog
+// https://developers.ceramic.network/protocol/streams/event-log/#data-event
+type Event InitEvent | DataEvent | TimeEvent
 
-- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+// https://cips.ceramic.network/CIPs/cip-124#eventids
+type EventId Bytes // sort-data + Event CID
 
----
+type SubscriptionResult {
+  events [EventId]
+	eventOffset Integer
+}
+```
 
 
-
-### `ceramic_reconPoll`
-
-Same as `ceramic_recon`, but waits for *duration* amount of time in case any new events arrives at the node during this time.
-
-**Params:**
-
-- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
-- *duration* <integer> - the amount of time, in seconds, to wait for new data
-
-**Returns:**
-
-- *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
 
 ---
 
+### GET `/ceramic/recon/{key*}`
+
+Interact with the node using the Recon protocol directly. This allows you to have greater control over the data you consume, but you have to be able to run the Recon algorithm client side.
+
+#### Example:
+
+```
+/ceramic/recon/kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr,kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr,kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr&duration=1000
+```
+
+#### Parameters:
+
+* _key*_ <Array<string>> - a comma separated list of eventids and ahashes (multicodec encoded), first and last key must be eventid, every even key must be an ahash
+* *duration* <integer> - the amount of time, in seconds, to wait for a response
+
+#### Returns:
+
+Content-Type:  `application/json`
+
+- _key*_ <array<string>> - a list of eventids and ahashes (multicodec encoded), first and last key must be eventid, every even key must be an ahash
 
 
-### `ceramic_exportRawEvents`
-
-Get the raw IPLD data of a set of events given an array of eventids. This includes all IPLD blocks for this particular event, but no data from the previous events, e.g. DataEvents include signature envelope, event, and potentially detached payload, while TimeEvents include their entire merkle tree witness.
-
-**Params:**
-
-- *[eventid]* <array<string>> - the events to fetch
-
-**Returns:**
-
-- *events* <string> - a base64 encoded CAR file containing the event blocks
 
 ---
 
+### GET `/ceramic/events/{eventid*}`
+
+Retrieve events given an array of eventids.
+
+#### Example:
+
+```
+/ceramic/events/kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr,kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr,kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr
+```
+
+#### Returns:
+
+**JSON:**
+
+Content-Type:  `application/json`
+
+This content type returns a json representation of the events requested. Note that this is just a representation of the event content, full verifiability is not retained.
+
+- *events* <array<object>> - the list of events
+  - *eventId* <string> - the id of the event
+  - *id* <string> - CID of the InitEvent for this stream
+  - *prev* <array<string>> - CIDs of previous hash linked events
+  - *header* <object> - header for the event
+  - *data* <object> - the data of the event
+  - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
+
+**CAR file:**
+
+Content-Type:  `application/vnd.ipld.car`
+
+This content types returns the underlaying IPLD data structure of the event streams encoded as a CAR file. This data can be used to trustlessly verify the integrity of the event stream. 
+
+The root object of the CAR file is *EventsResult* which is a convenience type containing an array of CIDs corresponding to the eventsids requested. The CAR file also includes all *Event* objects, including all IPLD blocks for these event, but no data from the previous events, e.g. DataEvents include signature envelope, event, and potentially detached payload, while TimeEvents include their entire merkle tree witness.
+
+```verilog
+// https://developers.ceramic.network/protocol/streams/event-log/#data-event
+type Event InitEvent | DataEvent | TimeEvent
+
+type Events [&Event]
+```
 
 
-### `ceramic_putRawEvent`
-
-Add an event to a stream.
-
-**Params:**
-
-- *event* <string> - a base64 encoded CAR file containing the event
-
-**Returns:**
-
-- *success* <boolean> - true if the event was added correctly
 
 ---
 
+### POST `/ceramic/events`
 
+Adds a new event to the node.
 
-### `ceramic_putEvent`
+#### Request body:
 
-Convenience method for adding an event by only submitting a JWT.
+The request body must contain the complete event data.
+
+**CAR:**
+
+Content-Type:  `application/vnd.ipld.car`
+
+A CAR file where the root is an *Event* as described below.
+
+```verilog
+// https://developers.ceramic.network/protocol/streams/event-log/#data-event
+type Event InitEvent | DataEvent | TimeEvent
+```
+
+**JSON:**
+
+Content-Type:  `application/json`
+
+A possible convenience method for adding an event by only submitting a JWT.
 
 Only possible once we’ve migrated to use *Varsig* and can create events as plain signed JWTs.
 
-**Params:**
+```javascript
+{
+  event: "<jwt>"
+}
+```
 
-- *event* <string> - a jwt containing the event
+#### Returns:
 
-**Returns:**
+**JSON:**
 
 - *success* <boolean> - true if the event was added correctly
+
+
+
+---
+
+### GET `/stats/active-ranges`
+
+A status endpoint that returns all ranges that this node is actively monitoring.
+
+#### Returns:
+
+* *ranges* <array<object>> - a list of all subscriptions
+  * *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
+  * *eventOffset* <integer> - the total number of events observed in this range
+
+
 
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-The choice of using json-rpc enables the API to work over multiple different transports. For example, HTTP, web sockets, or event the iframe postMessage api. The latter could be useful in the future if one want's to run a node inside of an iframe.
+The choice of using a REST API enables ease of integration and content types to more easily send and respond using binary formats such as CAR files. It's also a common pattern to have service workers serve http requests opening up for future browser native implementations of the Ceramic protocol.
 
 There are two main ways of polling for new events. Using recon and a more simple poll. This enables advanced developers to get full control with recon, while a simple poll API based on a single event counter is much easier to use for most developers. The disadvantage of the latter is that events will be received in the order that the node received them, not in the global order of the network.
 

--- a/CIPs/cip-137.md
+++ b/CIPs/cip-137.md
@@ -18,7 +18,7 @@ An API for reading and writing events on Ceramic event streams.
 
 ## Abstract
 <!--A short (~200 word) description of the technical issue being addressed.-->
-This CIP introduces a REST API that can be used to subscribe to a number of streams inside of an interest range, and write new events to these streams. The API exposes two main ways of retrieving events. A simple method that uses the nodes local ordering of events to retrieve events by simply keeping track of a single vector client side. More advanced users can use a simplified version of the [Recon](https://cips.ceramic.network/CIPs/cip-124) protocol to retrieve events in their logical order.
+This CIP introduces a OpenAPI specification that can be used to subscribe to a number of streams inside of an interest range, and write new events to these streams. The API exposes two main ways of retrieving events. A simple method that uses the nodes local ordering of events to retrieve events by simply keeping track of a single vector client side. More advanced users can use a simplified version of the [Recon](https://cips.ceramic.network/CIPs/cip-124) protocol to retrieve events in their logical order.
 
 
 ## Motivation
@@ -29,7 +29,7 @@ In order to enable services and databases other than ComposeDB to be built on to
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature.-->
 
-This specification introduces a REST API for interacting directly with event streams on a node.
+This specification introduces a OpenAPI spec for interacting directly with event streams on a node.
 
 
 
@@ -39,12 +39,14 @@ This endpoint is called to subscribe to new events in a given interest range. Th
 
 The range is normally defined as `ceramic://*?<sort-key>=<sort-value>`, where *sort-key* describes a field in the header of the InitEvent of a stream, and *sort-value* is the value of this field. For example to subscribe to all MIDs of a particular Model you can use `ceramic://*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr`.
 
-This endpoint will respond as soon as the node knows about new events, given the *eventOffset*, or when *duration* amount of seconds has passed.
+This endpoint will respond as soon as the node knows about new events, given the *offset*, or when *duration* amount of seconds has passed. If the node already knows about a lot of new events, only *limit* amount of events will be returned.
+
+The first time a client makes a request for a given interest range, the node creates a log file where eventId bytes are written as they are observed from the network (or locally). This log file is then used to allow the node to easily find events given an *offset* from the client.
 
 #### Example:
 
 ```
-/ceramic/subscribe/*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr&ctrlRangeStart=0x0000000000000000&ctrlRangeEnd=0xffffffffffffffff&eventOffset=123&duration=1000
+/ceramic/subscribe/*?model=kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr&ctrlRangeStart=0x0000000000000000&ctrlRangeEnd=0xffffffffffffffff&offset=123&limit=5&duration=1000
 ```
 
 #### Parameters:
@@ -54,7 +56,8 @@ This endpoint will respond as soon as the node knows about new events, given the
 * *{sort-key}* <string> - the *sort-key* and *sort-value* to subscribe to (e.g. `model` and `kjzl6hvfrbw6c82mkud4qs38zl4hd03ifoyg2ksvfjkhuxebfzh3ef89vwvtvrr` respectively)
 * *ctrlRangeStart* <string> - hex encoded string describing the start of the range of controllers to sync (defaults to `0x0000000000000000`)
 * *ctrlRangeEnd* <string> - hex encoded string describing the end of the range of controllers to sync (defaults to `0xffffffffffffffff`)
-* *eventOffset* <integer> - the number of events already consumed
+* *offset* <integer> - the number of eventId bytes already consumed
+* *limit* <integer> - the max number of events to return
 * *duration* <integer> - the amount of time, in seconds, to wait for a response
 
 
@@ -75,7 +78,7 @@ This content type returns a json representation of the events received. Note tha
   - *header* <object> - header for the event
   - *data* <object> - the data of the event
   - *timestamp* <integer> - the unixtime this event was timestamped (if it has been)
-- *eventOffset* <integer> - the number of events consumed
+- *offset* <integer> - the number of eventId bytes already consumed
 
 
 
@@ -85,7 +88,7 @@ Content-Type:  `application/vnd.ipld.car`
 
 This content types returns the underlaying IPLD data structure of the event streams encoded as a CAR file. This data can be used to trustlessly verify the integrity of the event stream. 
 
-The root object of the CAR file is a *SubscriptionResult* which contains an array of *EvenIds* the new *eventOffset*. The CAR file also includes all *Event* objects, corresponding to the eventids in the subscription result.
+The root object of the CAR file is a *SubscriptionResult* which contains an array of *EvenIds* the new *offset*. The CAR file also includes all *Event* objects, corresponding to the eventids in the subscription result.
 
 It's worth noting that an *EventId* always includes the CID of its *Event*.
 
@@ -98,7 +101,7 @@ type EventId Bytes // sort-data + Event CID
 
 type SubscriptionResult {
   events [EventId]
-	eventOffset Integer
+	offset Integer
 }
 ```
 
@@ -108,7 +111,7 @@ type SubscriptionResult {
 
 ### GET `/ceramic/recon/{key*}`
 
-Interact with the node using the Recon protocol directly. This allows you to have greater control over the data you consume, but you have to be able to run the Recon algorithm client side.
+Interact with the node using the [Recon protocol](https://cips.ceramic.network/CIPs/cip-124) directly. This allows you to have greater control over the data you consume, but you have to be able to run the Recon algorithm client side.
 
 #### Example:
 
@@ -232,7 +235,7 @@ A status endpoint that returns all ranges that this node is actively monitoring.
 
 * *ranges* <array<object>> - a list of all subscriptions
   * *reconRange* <Array<string>> - a Recon message, *`[eventid or ahash]`*
-  * *eventOffset* <integer> - the total number of events observed in this range
+  * *offset* <integer> - the total number of eventId bytes observed in this range
 
 
 
@@ -240,9 +243,13 @@ A status endpoint that returns all ranges that this node is actively monitoring.
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
 
-The choice of using a REST API enables ease of integration and content types to more easily send and respond using binary formats such as CAR files. It's also a common pattern to have service workers serve http requests opening up for future browser native implementations of the Ceramic protocol.
+The choice of using OpenAPI enables ease of integration and content types to more easily send and respond using binary formats such as CAR files. It's also a common pattern to have service workers serve http requests opening up for future browser native implementations of the Ceramic protocol.
 
 There are two main ways of polling for new events. Using recon and a more simple poll. This enables advanced developers to get full control with recon, while a simple poll API based on a single event counter is much easier to use for most developers. The disadvantage of the latter is that events will be received in the order that the node received them, not in the global order of the network.
+
+### Offset using EventId bytes
+
+One question that might arise is why the poll api (e.g. `/ceramic/subscribe/`) couldn't also return events in the global order of the network. The reason for this is that the node might not receive the events in this order from the network, and we want to be able to tell clients about events as they come in. Therefore we store a log of eventId bytes in the order they were observed (and validated) given a particular interest range. This allows clients to have a simple incrementing byte offset counter, while the node doesn't need to keep client specific state.
 
 
 ## Backwards Compatibility


### PR DESCRIPTION
After some discussions with @stbrody it seems like using a REST api could be a good idea since it allows us to use multiple content types, among other benefits.

This PR proposes changing to using an http REST api. It also simplifies the api by reducing the number of endpoints needed.