### PR TITLE
CIP-142: LinkFeed composeDB document schema draft CIP RFC

### DIFF
--- a/CIPs/cip-142.md
+++ b/CIPs/cip-142.md
@@ -51,6 +51,7 @@ Web feed is a common concept. Many types of information can be shaped into this 
 
 ## Specification
 <!--The technical specification should describe the syntax and semantics of any new feature.-->
+```graphql
 type Linkfeed @createModel(accountRelation: LIST, description: "A feed abstraction standard.") {
   title: String! @string(maxLength: 2000) 
 	content: String! @string(maxLength: 100000)
@@ -63,6 +64,7 @@ type Linkfeed @createModel(accountRelation: LIST, description: "A feed abstracti
   createAt: DateTime
   modifiedAt: DateTime
 }
+```
 
 ## Rationale
 <!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->

--- a/CIPs/cip-x-linkfeed-schema.md
+++ b/CIPs/cip-x-linkfeed-schema.md
@@ -1,5 +1,5 @@
 ---
-cip: <to be assigned>
+cip: 142
 title: LinkFeed - a content feed abstraction standard
 author: Pan Zhixiong (@nake13), dugubuyan (@dugubuyan) and Liang Qiao (@qbig)
 discussions-to: https://forum.ceramic.network/t/linkfeed-schema-rfc-wip/1199

--- a/CIPs/cip-x-linkfeed-schema.md
+++ b/CIPs/cip-x-linkfeed-schema.md
@@ -7,8 +7,6 @@ status: Draft
 category: RFC
 created: 2023-06-28
 edited: 2023-06-28
-requires: <EIP number(s)>
-replaces: <EIP number(s)>
 ---
 
 <!--PROPOSE A NEW CIP-->

--- a/CIPs/cip-x-linkfeed-schema.md
+++ b/CIPs/cip-x-linkfeed-schema.md
@@ -1,0 +1,78 @@
+---
+cip: <to be assigned>
+title: LinkFeed - a content feed abstraction standard
+author: Pan Zhixiong (@nake13), dugubuyan (@dugubuyan) and Liang Qiao (@qbig)
+discussions-to: https://forum.ceramic.network/t/linkfeed-schema-rfc-wip/1199
+status: Draft
+category: RFC
+created: 2023-06-28
+edited: 2023-06-28
+requires: <EIP number(s)>
+replaces: <EIP number(s)>
+---
+
+<!--PROPOSE A NEW CIP-->
+
+<!--NOTE: 
+You can leave these HTML comments in your CIP and delete the visible text guides, they will not appear and may be helpful to refer to if you edit your CIP again.-->
+
+<!-- STEPS TO SUBMIT A CIP:
+1. Complete the header above.
+2. Fill in as much content as is appropriate for the status of your CIP.-->
+
+<!--ADDITIONAL INSTRUCTIONS FOR HEADER SECTION ABOVE-->
+
+<!--[title]: Give your issue a concise, descriptive title prefixed by either its *type* for standards CIPs or its category for other CIPs. (i.e. Core: Protocol Upgrade, Meta: Define CIP Process, etc.).-->
+
+<!--[category]: Here is a description of category terms.
+- `Core`: an CIP that affects the core protocol.
+- `Networking`: an CIP thst affects the networking layer (i.e. libp2p or syncing).
+- `Interface`: an CIP that affects the Ceramic API or provider interface.
+- `RFC`: an CIP that proposes an implementation standard (i.e. doctypes, document configurations, or document schemas).
+- `Meta`: an CIP that affects the governance process for CIPs.-->
+
+<!--[requires]: A list of CIP(s) that this CIP depends on. *Optional.-->
+
+<!--[replaces]: A list of CIP(s) that this CIP replaces. *Optional.-->
+
+## Simple Summary
+<!--Provide a simplified and layman-accessible explanation of the CIP.-->
+LinkFeed is a feed abstraction standard built on top of Ceramic ComposeDB. You can use LinkFeed SDK to build anything related to feed. A older version was implemented using TileDocument here https://github.com/chainfeeds/linkfeed.
+
+## Abstract
+<!--A short (~200 word) description of the technical issue being addressed.-->
+Abstract goes here.
+
+
+## Motivation
+<!--Motivation is critical for CIPs that want to change the Ceramic protocol. It should clearly explain why the existing protocol specification is inadequate to address the problem that the CIP solves. CIP submissions without sufficient motivation may be rejected outright.-->
+Motivation goes here.
+
+
+## Specification
+<!--The technical specification should describe the syntax and semantics of any new feature.-->
+Specification goes here.
+
+
+## Rationale
+<!--The rationale fleshes out the specification by describing what motivated the design and why particular design decisions were made. It should describe alternate designs that were considered and related work, e.g. how the feature is supported in other languages. The rationale may also provide evidence of consensus within the community, and should discuss important objections or concerns raised during discussion.-->
+Rationale goes here.
+
+
+## Backwards Compatibility
+<!--All CIPs that introduce backwards incompatibilities must include a section describing these incompatibilities and their severity. The CIP must explain how the author proposes to deal with these incompatibilities. CIP submissions without a sufficient backwards compatibility section may be rejected outright.-->
+Backwards compatibility goes here.
+
+
+## Implementation
+<!--The implementations must be completed before any CIP is given status "Final", but it need not be completed before the CIP is accepted.-->
+Implementation goes here.
+
+
+## Security Considerations
+<!--All CIPs must contain a section that discusses the security implications/considerations relevant to the proposed change. Include information that might be important for security discussions, surfaces risks and can be used throughout the life cycle of the proposal. E.g. include security-relevant design decisions, concerns, important discussions, implementation-specific guidance and pitfalls, an outline of threats and risks and how they are being addressed. CIP submissions missing the "Security Considerations" section will be rejected. An CIP cannot proceed to status "Final" without a Security Considerations discussion deemed sufficient by the reviewers.-->
+Security considerations go here.
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
LinkFeed is a feed abstraction standard built on top of Ceramic ComposeDB. You can use LinkFeed SDK to build anything related to feed. A older version was implemented using TileDocument here https://github.com/chainfeeds/linkfeed.