### PR TITLE
chore: Change code in CIP-110 to conform with the implementation

### DIFF
--- a/CIPs/cip-110.md
+++ b/CIPs/cip-110.md
@@ -3,10 +3,10 @@ cip: 110
 title: Ceramic Anchor Contract
 author: Sergey Ukustov <sergey@ukstv.me>
 discussions-to: https://github.com/ceramicnetwork/CIP/issues/110
-status: Review
+status: Final
 category: RFC
 created: 2021-10-14
-edited: 2023-05-24
+edited: 2023-07-03
 ---
 
 ## Simple Summary

--- a/CIPs/cip-110.md
+++ b/CIPs/cip-110.md
@@ -71,7 +71,7 @@ function removeCas(address _service) public {
 }
 ```
 
-The "anchor" function can be called by an allowed service only. Its responsibility is limited to just emit an event:
+The "anchorDagCbor" function can be called by an allowed service only. The single parameter `root` contains bytes (i.e. without multibase prefix) of an anchor Merkle root's CID. The function's responsibility is limited to just emit an event:
 
 ```solidity=
 // Only an address in the allowlist is allowed.

--- a/CIPs/cip-110.md
+++ b/CIPs/cip-110.md
@@ -44,7 +44,7 @@ We can achieve that using a smart contract on Ethereum network (as our main netw
 
 ### Implementation details
 
-The contract should be written in Solidity language, using Truffle or Hardhat toolboxes. It might use [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) library.
+The contract should be written in Solidity language, using Truffle, Hardhat, or Foundry toolboxes. It might use [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-contracts) library.
 
 For "ownable" feature we are going to extend our contract [`Ownable`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/access/Ownable.sol) from OpenZeppelin. The functionality provided there is good enough, so we do not elaborate on that topic further.
 
@@ -52,21 +52,21 @@ The allowlist is maintained as `mapping (address => bool)`. We use two functions
 
 
 ```solidity=
-mapping (address => bool) allowlist;
+mapping (address => bool) allowList;
 
 event DidAddCas(address indexed _service);
 event DidRemoveCas(address indexed _service);
 
-// Only owner can add to the allowlist
+// Only owner can add to the allowList
 function addCas(address _service) public onlyOwner {
-    allowlist[_service] = true;
+    allowList[_service] = true;
     emit DidAddCas(_service);
 }
     
 // Removal can be performed by the owner or the service itself
 function removeCas(address _service) public {
-    require((owner() == _msgSender()) || (allowlist[_msgSender()] && _msgSender() === _service), "Caller is not allowed or the owner");
-    delete allowlist[_service];
+    require((owner() == _msgSender()) || (allowList[_msgSender()] && _msgSender() == _service), "Caller is not allowed or the owner");
+    delete allowList[_service];
     emit DidRemoveCas(_service);
 }
 ```
@@ -76,15 +76,17 @@ The "anchor" function can be called by an allowed service only. Its responsibili
 ```solidity=
 // Only an address in the allowlist is allowed.
 modifier onlyAllowed() {
-    require(allowlist[_msgSender()], "Allowlist: caller is not allowed");
+    require(
+            ( allowList[ msg.sender ] || msg.sender == owner() ), 
+            "Allow List: caller is not allowed");
     _;
 }
 
-event DidAnchor(address indexed _service, bytes _root);
+event DidAnchor(address indexed _service, bytes32 _root);
 
 // Here _root is a byte representation of Merkle root CID.
-function anchor(bytes calldata _root) public onlyAllowed {
-    emit DidAnchor(_msgSender(), _root);
+function anchorDagCbor(bytes32 _root) public onlyAllowed {
+    emit DidAnchor(msg.sender, _root);
 }
 ```
 


### PR DESCRIPTION
- Change `allowlist` in code samples to `allowList`
- Change `===` to actual Solidity equality operator `==`
- `bytes` to `bytes32`, again to use actual Solidity code
- Describe `anchorDagCbor`, renamed from initial `anchor`.

Other than that, it seems CIP-110 reflects the contract well.